### PR TITLE
 move from legacy dataset available under geoip to the current dataset under client.geo

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -54,7 +54,7 @@ sub vcl_recv {
         set req.http.x-upp-backend="EU";
         
 	    # Use US s3 bucket if the request is from the America & Asia, or EU (default) is unhealthy
-	    if (geoip.continent_code ~ "(NA|SA|OC|AS)" || !req.backend.healthy) {
+	    if (client.geo.continent_code ~ "(NA|SA|OC|AS)" || !req.backend.healthy) {
 		    set req.backend = s3_us;
 		    set req.http.Host = "com.ft.imagepublish.upp-prod-us.s3.amazonaws.com";
 		    set req.http.x-upp-backend="US";


### PR DESCRIPTION
# Description

## What

Migrating the codebase from the legacy dataset for geolocation data

## Why

The old dataset is looking to be retired soon - approximately May 2022

## Anything, in particular, you'd like to highlight to reviewers

The data returned for a given IP address may be different between the current and legacy datasets, especially at the city level.
The other differences between the two datasets are:
    Results for IPv6 addresses are only returned in the new dataset.
    The datasets each have different formatting conventions. For example, `client.geo.city` and `client.geo.country_name` exist as lowercase ASCII values whereas the values returned for the same fields in the `geoip.` namespace are mixed case.
    The `client.geo.region` field contains ISO 3166-2 region codes but the `geoip.region` field contains FIPS10-4 region codes. 

More documentation about this can be found at https://developer.fastly.com/reference/vcl/variables/geolocation/

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
