### PR TITLE
Remove use of deprecated GeoIP VCL variable

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -54,7 +54,7 @@ sub vcl_recv {
         set req.http.x-upp-backend="EU";
         
 	    # Use US s3 bucket if the request is from the America & Asia, or EU (default) is unhealthy
-	    if (geoip.continent_code ~ "(NA|SA|OC|AS)" || !req.backend.healthy) {
+	    if (client.geo.continent_code ~ "(NA|SA|OC|AS)" || !req.backend.healthy) {
 		    set req.backend = s3_us;
 		    set req.http.Host = "com.ft.imagepublish.upp-prod-us.s3.amazonaws.com";
 		    set req.http.x-upp-backend="US";


### PR DESCRIPTION
Fastly are dropping support for the deprecated GeoIP VCL variables under the `geoip.` path. 

They have been replaced by a new set of variables, which provides an almost identical set of data, under the `client.geo.` path.

See https://developer.fastly.com/reference/vcl/variables/geolocation/ for the details.

No deployment is strictly necessary as Fastly will make this change to active services later on in May 2022.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
